### PR TITLE
Change fs-person portrait image element to position: absolute

### DIFF
--- a/fs-person/fs-person.html
+++ b/fs-person/fs-person.html
@@ -87,6 +87,7 @@ Example:
         align-items: center;
         justify-content: center;
         overflow: hidden;
+        position: relative;
         @apply(--fs-person-portrait);
       }
       :host([orientation='portrait']) .fs-person-portrait__container {

--- a/fs-person/fs-person.html
+++ b/fs-person/fs-person.html
@@ -100,6 +100,7 @@ Example:
       .fs-person-portrait__portrait-image {
         width: 100%;
         height: 100%;
+        position: absolute;
       }
 
       a:visited {


### PR DESCRIPTION
This will make the portrait image display on top of the placeholder icon and not next to it. Primarily, this is for fixing broken images where both are seen. Regular portraits, or those without portraits appear to be fine.
Before: 
![screen shot 2016-11-15 at 8 39 08 am](https://cloud.githubusercontent.com/assets/10411450/20320449/23af8c6a-ab2f-11e6-97f2-23c50f019567.png)
After:
![screen shot 2016-11-15 at 8 39 15 am](https://cloud.githubusercontent.com/assets/10411450/20320457/290bb5c6-ab2f-11e6-98f7-1389f30c4203.png)
