### PR TITLE
Add openPersonCard and hidePid attributes.

### DIFF
--- a/fs-person/fs-person.html
+++ b/fs-person/fs-person.html
@@ -121,6 +121,12 @@ Example:
       a {
         text-decoration: none;
       }
+      :host([inline]) a {
+        color: #333331;
+      }
+      :host([inline]) a:hover {
+        text-decoration: underline;
+      }
     </style>
     <div class='fs-person__container'>
       <div class="fs-person-portrait" hidden='[[inline]]'>
@@ -134,25 +140,39 @@ Example:
         <div class="fs-person-vitals">
           <div class='v-center'>
             <fs-icon class='fs-person-gender__icon' icon='[[gender]]-dot' size='small' hidden='[[!_showGenderDot(inline, showPortrait, gender, orientation)]]'></fs-icon>
-            <span class="fs-person-vitals__name-block" hidden="[[!destination]]">
-              <a href="[[destination]]" class='fs-person-vitals__name' hidden='[[_isPortrait(orientation)]]'>[[fullName]]</a>
-              <a href="[[destination]]" class='fs-person-vitals__name' hidden='[[!_isPortrait(orientation)]]'>
-                <span>[[_getFirstName(firstName, lastName, nameSystem)]]</span>
-                <span>[[_getLastName(firstName, lastName, nameSystem)]]</span>
-              </a>
-            </span>
-            <span class="fs-person-vitals__name-block" hidden="[[destination]]">
-              <p class='fs-person-vitals__name' hidden='[[_isPortrait(orientation)]]'>[[fullName]]</p>
-              <p class='fs-person-vitals__name' hidden='[[!_isPortrait(orientation)]]'>
-                <span>[[_getFirstName(firstName, lastName, nameSystem)]]</span>
-                <span>[[_getLastName(firstName, lastName, nameSystem)]]</span>
-              </p>
-            </span>
+            <div hidden="[[!openPersonCard]]">
+              <span id="fsPersonName" class="fs-person-vitals__name-block">
+                <!-- This must use on-click instead of on-tap in order to capture cmd + click or ctrl + click events -->
+                <a href="[[destination]]" on-click="_openPersonCard" class='fs-person-vitals__name' hidden='[[_isPortrait(orientation)]]'>[[fullName]]</a>
+                <a href="[[destination]]" on-click="_openPersonCard" class='fs-person-vitals__name' hidden='[[!_isPortrait(orientation)]]'>
+                  <span>[[_getFirstName(firstName, lastName, nameSystem)]]</span>
+                  <span>[[_getLastName(firstName, lastName, nameSystem)]]</span>
+                </a>
+              </span>
+            </div>
+            <div hidden="[[openPersonCard]]">
+              <span class="fs-person-vitals__name-block" hidden="[[!destination]]">
+                <a href="[[destination]]" class='fs-person-vitals__name' hidden='[[_isPortrait(orientation)]]'>[[fullName]]</a>
+                <a href="[[destination]]" class='fs-person-vitals__name' hidden='[[!_isPortrait(orientation)]]'>
+                  <span>[[_getFirstName(firstName, lastName, nameSystem)]]</span>
+                  <span>[[_getLastName(firstName, lastName, nameSystem)]]</span>
+                </a>
+              </span>
+              <span class="fs-person-vitals__name-block" hidden="[[destination]]">
+                <p class='fs-person-vitals__name' hidden='[[_isPortrait(orientation)]]'>[[fullName]]</p>
+                <p class='fs-person-vitals__name' hidden='[[!_isPortrait(orientation)]]'>
+                  <span>[[_getFirstName(firstName, lastName, nameSystem)]]</span>
+                  <span>[[_getLastName(firstName, lastName, nameSystem)]]</span>
+                </p>
+              </span>
+            </div>
           </div>
           <div class$='fs-person-details__container [[_getDetailsClass(inline, showPortrait, gender, orientation)]]'>
             <span>[[lifespan]]</span>
-            <span class="fs-person-details__separator" hidden='[[!_and(pid, lifespan)]]'>&nbsp;•&nbsp;</span>
-            <span>[[pid]]</span>
+            <div hidden$='[[!_showPid(pid, hidePid)]]'>
+              <span class="fs-person-details__separator" hidden='[[!_and(pid, lifespan)]]'>&nbsp;•&nbsp;</span>
+              <span>[[pid]]</span>
+            </div>
           </div>
         </div>
       </div>
@@ -243,7 +263,7 @@ Example:
 
         /**
          * Whether or not the portrait image should be shown
-         * @type {String}
+         * @type {Boolean}
          */
         showPortrait: {
           type: Boolean,
@@ -261,7 +281,7 @@ Example:
 
         /**
          * Inline rendering of the person
-         * @type {String}
+         * @type {Boolean}
          */
         inline: {
           type: Boolean,
@@ -276,6 +296,24 @@ Example:
         destination: {
           type: String,
           value: ''
+        },
+
+        /**
+         * Whether the person card should be opened
+         * @type {Boolean}
+         */
+        openPersonCard: {
+          type: Boolean,
+          value: false
+        },
+
+        /**
+         * Whether the person id should be shown
+         * @type {Boolean}
+         */
+        hidePid: {
+          type: Boolean,
+          value: false
         }
 
       },
@@ -285,6 +323,20 @@ Example:
 
       _and: function(a, b) {
         return a && b;
+      },
+      _showPid: function(pid, hidePid) {
+        return (pid && !hidePid);
+      },
+      _openPersonCard: function(e){
+        if (this.openPersonCard && document.querySelector("person-card") && !(e.metaKey || e.ctrlKey)) {
+          // Cancel out the link's href
+          e.preventDefault();
+          // Cancel the person card's default click event.
+          e.stopPropagation();
+          // Open the person card
+          this.fire("openPersonCard", {"element": this.$.fsPersonName.querySelector(".fs-person-vitals__name"), "personId": this.pid});
+        }
+        return;
       },
       _portraitDefault: function(showPortrait, orientation) {
         if (orientation === 'portrait' && !showPortrait) {


### PR DESCRIPTION
hidePid is needed because inline people sometimes have a pid for opening person card, but we don't want to show it.

_openPersonCard() checks to see if the attribute is set and the person card exists on the page before triggering an event. The event listener and handler is in [person-card.html](https://github.com/fs-webdev/tree/blob/person-card/assets/elements/person-card/person-card.html#L433-L458). Although using a global event isn't the greatest way of doing things, it allows us to open a single instance of person card from anywhere without having to import it as a dependency (which would create a circular dependency if added here).

As a side note, we want to keep the destination href with openPersonCard, so that the href can be opened instead of the person card when a cmd + click or ctrl + click is used on the name.