### PR TITLE
Prevent other events from firing when copy icon is clicked.

### DIFF
--- a/fs-person/fs-person.html
+++ b/fs-person/fs-person.html
@@ -328,6 +328,7 @@ Example:
       },
       _copyPid: function(e) {
         e.preventDefault();
+        // Stop any other events from firing (like opening the person card or person page)
         e.stopImmediatePropagation();
         this.$._pidInput.select();
         document.execCommand('copy');

--- a/fs-person/fs-person.html
+++ b/fs-person/fs-person.html
@@ -328,6 +328,7 @@ Example:
       },
       _copyPid: function(e) {
         e.preventDefault();
+        e.stopImmediatePropagation();
         this.$._pidInput.select();
         document.execCommand('copy');
         window.getSelection().removeAllRanges();


### PR DESCRIPTION
This makes it so clicking on the copy icon doesn't open the person card or person page.