### PR TITLE
Fix a11ySuite tests that run against elements with fs-person

### DIFF
--- a/fs-person/fs-person.html
+++ b/fs-person/fs-person.html
@@ -190,7 +190,9 @@ Example:
                 <fs-icon class='copy-icon' icon='copy'></fs-icon>
                 [[pid]]
               </span>
-              <input id='_pidInput' type="text" value$='[[pid]]'>
+              <label>
+                <input id="_pidInput" type="text" value$="[[pid]]">
+              </label>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Input needs to have a label to satisfy the usability tests.

@jshcrowthe This will fix the builds for tree v8. The only other option I can come up with is removing the a11y suite from our unit tests, but that doesn't sound good for the long-term.