### PR TITLE
Fix the copy icon to work with other click events.

### DIFF
--- a/fs-person/fs-person.html
+++ b/fs-person/fs-person.html
@@ -186,7 +186,7 @@ Example:
             <span>[[lifespan]]</span>
             <div hidden$='[[!_showPid(pid, hidePid)]]'>
               <span class="fs-person-details__separator" hidden='[[!_and(pid, lifespan)]]'>&nbsp;•&nbsp;</span>
-              <span class='fs-person-details__pid' on-tap='_copyPid'>
+              <span class='fs-person-details__pid' on-click='_copyPid'>
                 <fs-icon class='copy-icon' icon='copy'></fs-icon>
                 [[pid]]
               </span>


### PR DESCRIPTION
Since we changed fs-tree-person-renderer to use click events, this needs to change as well so it can stop them from firing.