### PR TITLE
Bug fixes for portraits in ie11.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "styles-wc",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Global styles for the FamilySearch.org website.",
   "keywords": [
     "css",

--- a/fs-person/fs-person.html
+++ b/fs-person/fs-person.html
@@ -115,6 +115,11 @@ fs-person:not([inline]) {
         align-items: center;
       }
 
+      /* Bug fix to keep portrait container from shrinking in ie11. */
+      .fs-person-portrait {
+        flex-shrink: 0;
+      }
+
       .fs-person__container > .v-center,
       .fs-person-vitals > .v-center {
         overflow-x: hidden;
@@ -192,6 +197,10 @@ fs-person:not([inline]) {
       .fs-person-portrait__portrait-image {
         width: 100%;
         height: 100%;
+        /* Bug fix so portraits and broken images don't appear side-by-side with icon: */
+        position: absolute;
+        top: 0px; /* Required for ie11 */
+        left: 0px;
         @apply(--fs-person-portrait-image);
       }
       a:visited {


### PR DESCRIPTION
I couldn't find any problems while testing absolute positioned portraits. If something comes up where they don't fit in their container, we'll investigate it more.