### PR TITLE
fs-person: add hide-separator property

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "styles-wc",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Global styles for the FamilySearch.org website.",
   "keywords": [
     "css",

--- a/fs-person/demo/index.html
+++ b/fs-person/demo/index.html
@@ -121,6 +121,11 @@
       border: 1px solid #333;
       margin-bottom: 5px;
     }
+    fs-person {
+      --fs-person-name-v-center: {
+        overflow: visible;
+      }
+    }
     .big-portrait {
       --fs-person-portrait: {
         width: 200px;

--- a/fs-person/fs-person.html
+++ b/fs-person/fs-person.html
@@ -100,7 +100,7 @@ fs-person:not([inline]) {
         white-space: nowrap;
         @apply --fs-person-details;
       }
-      .fs-person-details__pid {
+      .fs-person-details__pid .copy-icon {
         cursor: pointer;
       }
       :host([orientation='portrait']) .fs-person-details__container {
@@ -311,7 +311,7 @@ fs-person:not([inline]) {
           <div class$='fs-person-details__container [[_getDetailsClass(inline, showPortrait, hideGender, orientation)]]'>
             <span data-test-person-lifespan>[[lifespan]]</span>
             <div hidden$='[[!_showPid(pid, hidePid)]]'>
-              <span class="fs-person-details__separator" hidden='[[!_and(pid, lifespan)]]'>&nbsp;•&nbsp;</span>
+              &nbsp;<span class="fs-person-details__separator" hidden='[[_hideSeparator(hideSeparator, pid, lifespan)]]'>•</span>&nbsp;
               <span class='fs-person-details__pid'>
                 <fs-icon class='copy-icon tooltipped' icon='copy' aria-label$='[[i18n("COPY_TO_CLIPBOARD")]]' on-click='_copyPid' title='' data-test-person-copy-pid-button></fs-icon>
                 <span data-test-person-pid>[[pid]]</span>
@@ -452,6 +452,15 @@ fs-person:not([inline]) {
         },
 
         /**
+         * Whether or not to show the spearator dot (•)
+         * @type {Boolean}
+         */
+        hideSeparator: {
+          type: Boolean,
+          value: false
+        },
+
+        /**
          * Whether the person id should be shown
          * @type {Boolean}
          */
@@ -470,10 +479,6 @@ fs-person:not([inline]) {
 
       handlePortraitError: function(e) {
         this.portraitUrl = false;
-      },
-
-      _and: function(a, b) {
-        return a && b;
       },
       _copyPid: function(e) {
         var that = this,
@@ -529,6 +534,9 @@ fs-person:not([inline]) {
         }
 
         return 'unknown-portrait';
+      },
+      _hideSeparator: function(hideSeparator, pid, lifespan) {
+        return (hideSeparator || !(pid && lifespan));
       },
       _isPortrait: function(orientation) {
         return orientation === 'portrait';

--- a/test/fs-person_test.html
+++ b/test/fs-person_test.html
@@ -68,6 +68,7 @@
             expect(fsPersonDefault.gender, "gender is not ''").to.equal('');
             expect(fsPersonDefault.hideGender, "hideGender is not false").to.be.false;
             expect(fsPersonDefault.hidePid, "hidePid is not false").to.be.false;
+            expect(fsPersonDefault.hideSeparator, "hideSeparator is not false").to.be.false;
             expect(fsPersonDefault.inline, "inline is not false").to.be.false;
             expect(fsPersonDefault.lastName, "lastName is not ''").to.equal('');
             expect(fsPersonDefault.lifespan, "lifespan is not ''").to.equal('');
@@ -97,6 +98,7 @@
           it('should hide gender and pid ', function () {
             expect(fsPersonPassedValues.hideGender, "hideGender is not true").to.be.true;
             expect(fsPersonPassedValues.hidePid, "hidePid is not true").to.be.true;
+            expect(fsPersonPassedValues.hideSeparator, "hideSeparator is not false").to.be.false;
           });
 
           it('should be inline ', function () {
@@ -144,15 +146,6 @@
         //     expect(fsPersonPassedValues.portraitUrl, "portraitUrl is not false").to.be.false;
         //   });
         // });
-
-        describe('_and', function() {
-          it('should return a and b', function () {
-            expect(fsPersonDefault._and(true, true), "true & true returned false").to.be.true;
-            expect(fsPersonDefault._and(true, false), "true & false returned true").to.be.false;
-            expect(fsPersonDefault._and(false, true), "false & true returned true").to.be.false;
-            expect(fsPersonDefault._and(false, false), "false & false returned true").to.be.false;
-          });
-        });
 
         describe('_copyPid', function() {
           var mockEvent;
@@ -211,6 +204,20 @@
             expect(fsPersonDefault._showPid(true, true), "pid exists and hide it returned true").to.be.false;
             expect(fsPersonDefault._showPid(false, true), "no pid exists and hide it returned true").to.be.false;
             expect(fsPersonDefault._showPid(false, false), "no pid exists and don't hide it returned true").to.be.false;
+          });
+        });
+
+        describe('_hideSeparator', function() {
+          it('should return true (not show the separator)', function () {
+            expect(fsPersonDefault._hideSeparator(true, true, true), "hideSeparator=true, pid=true, lifespan=true").to.be.true;
+            expect(fsPersonDefault._hideSeparator(true, false, false), "hideSeparator=true, pid=false, lifespan=false").to.be.true;
+            expect(fsPersonDefault._hideSeparator(false, false, true), "hideSeparator=false, pid=false, lifespan=true").to.be.true;
+            expect(fsPersonDefault._hideSeparator(false, true, false), "hideSeparator=false, pid=true, lifespan=false").to.be.true;
+            expect(fsPersonDefault._hideSeparator(false, false, false), "hideSeparator=false, pid=false, lifespan=false").to.be.true;
+          });
+
+          it('should return false (show the separator)', function () {
+            expect(fsPersonDefault._hideSeparator(false, true, true), "hideSeparator=false, pid=true, lifespan=true").to.be.false;
           });
         });
 


### PR DESCRIPTION
Add hideSeparator check (replaces _and() function)
CSS fixes: allow overflow for PID copier tooltip & cursor: pointer only on button.
Add/update unit tests.