### PR TITLE
Possible bug fix for CSS mixins

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "styles-wc",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "Global styles for the FamilySearch.org website.",
   "keywords": [
     "css",

--- a/fs-person/fs-person.html
+++ b/fs-person/fs-person.html
@@ -85,7 +85,7 @@ fs-person:not([inline]) {
         font-weight: normal;
         line-height: 1.625rem;
         margin: 0;
-        @apply --fs-person-name;
+        @apply(--fs-person-name);
       }
       .fs-person-name__container {
         display: -webkit-flex;
@@ -99,7 +99,7 @@ fs-person:not([inline]) {
         -webkit-flex-wrap: nowrap;
         flex-wrap: nowrap;
         white-space: nowrap;
-        @apply --fs-person-details;
+        @apply(--fs-person-details);
       }
       .fs-person-details__pid .copy-icon {
         cursor: pointer;
@@ -134,7 +134,7 @@ fs-person:not([inline]) {
       .fs-person__container {
         position: relative;
         z-index:0;
-        @apply --fs-person-container;
+        @apply(--fs-person-container);
       }
 
       /* This is a CSS hack to allow for easy copying of the PID */
@@ -226,7 +226,7 @@ fs-person:not([inline]) {
       }
 
       .fs-person__container > .v-center {
-        @apply --fs-person-name-v-center;
+        @apply(--fs-person-name-v-center);
       }
 
       .fs-person-gender__icon {
@@ -248,7 +248,7 @@ fs-person:not([inline]) {
         justify-content: center;
         overflow: hidden;
         position: relative;
-        @apply --fs-person-portrait;
+        @apply(--fs-person-portrait);
       }
       :host([orientation='portrait']) .fs-person-portrait__container {
         margin-right: 0;
@@ -257,13 +257,13 @@ fs-person:not([inline]) {
       .fs-person-portrait__portrait-icon[icon='male'] {
         width: 100%;
         height: 100%;
-        @apply --fs-person-portrait-icon;
+        @apply(--fs-person-portrait-icon);
       }
       .fs-person-portrait__portrait-icon[icon^='gray'],
       .fs-person-portrait__portrait-icon[icon^='unknown'] {
         width: 60%;
         height: 60%;
-        @apply --fs-person-portrait-icon;
+        @apply(--fs-person-portrait-icon);
       }
       .fs-person-portrait__portrait-image {
         width: 100%;
@@ -272,7 +272,7 @@ fs-person:not([inline]) {
         position: absolute;
         top: 0px; /* Required for ie11 */
         left: 0px;
-        @apply --fs-person-portrait-image;
+        @apply(--fs-person-portrait-image);
       }
       a:visited {
         color: blue;


### PR DESCRIPTION
For an unknown reason, the mixins for styles-wc/fs-person don't appear to be working in beta and prod (they seem alright locally). Everywhere that the mixins are working (fs-life-events, for example) the parentheses are present, so we're going to replace them here and see if that helps.