### PR TITLE
Bug fix: Person names spill out of pedigree containers

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "styles-wc",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "description": "Global styles for the FamilySearch.org website.",
   "keywords": [
     "css",

--- a/fs-person/fs-person.html
+++ b/fs-person/fs-person.html
@@ -113,7 +113,7 @@ fs-person:not([inline]) {
       .v-center,
       .fs-person-portrait,
       .fs-person__container {
-        display: inline-flex;
+        display: flex;
         flex-direction: row;
         align-items: center;
       }


### PR DESCRIPTION
Changing from display: inline-flex to display: flex allows the wrapping container to adjust its size dynamically, instead of allowing the content to spill out.

![screen shot 2017-04-10 at 12 22 26 pm](https://cloud.githubusercontent.com/assets/2700098/24876326/8c2ef6aa-1de8-11e7-97ad-dbf0a342351d.png)