### PR TITLE
OFT-69102 Fix copy pid functionality

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "styles-wc",
-  "version": "2.1.14",
+  "version": "2.1.15",
   "description": "Global styles for the FamilySearch.org website.",
   "keywords": [
     "css",

--- a/fs-person/demo/index.html
+++ b/fs-person/demo/index.html
@@ -27,7 +27,7 @@
 <body>
   <demo-snippet>
     <template>
-      <fs-person gender='male' pid='KWFF-1RH' full-name='Josh Crowther' lifespan='1776-1980'></fs-person>
+      <fs-person gender='male' pid='L5FF-YWL' full-name='Test Child' lifespan='1995-Deceased'></fs-person>
     </template>
   </demo-snippet>
   <demo-snippet>
@@ -47,7 +47,7 @@
   </demo-snippet>
   <demo-snippet>
     <template>
-      <fs-person gender='male' pid='KWFF-1RH' full-name='Josh Crowther'></fs-person>
+      <fs-person gender='male' pid='L5FF-BZ9' full-name='Child 1'></fs-person>
     </template>
   </demo-snippet>
   <demo-snippet>
@@ -107,7 +107,7 @@
   </demo-snippet>
   <demo-snippet>
     <template>
-      <fs-person class='top-align-text' gender='male' pid='KWFF-1RH' full-name='Josh Crowther' lifespan='1776-1980' show-portrait portrait-url='https://familysearch.org/patron/v2/TH-904-51257-1471-39/thumb200s.jpg?ctx=ArtCtxPublic'></fs-person>
+      <fs-person class='top-align-text' gender='female' pid='L5FF-YWG' full-name='Wife of Test Child' lifespan='1995–1999' show-portrait portrait-url='https://familysearch.org/patron/v2/TH-904-51257-1471-39/thumb200s.jpg?ctx=ArtCtxPublic'></fs-person>
     </template>
   </demo-snippet>
   <demo-snippet>

--- a/fs-person/fs-person.html
+++ b/fs-person/fs-person.html
@@ -143,7 +143,7 @@ fs-person:not([inline]) {
       #_pidInput {
         opacity: 0;
         position: absolute;
-        width: 1px;
+        width: 40px; /* Fix for OFT-69102 - copy pid not working for person-card or tree. */
         height: 1px;
         top:0;
         left:0;
@@ -157,13 +157,16 @@ fs-person:not([inline]) {
       }
 
       /* Begin GitHub-like css-only accessible tooltip */
+      .copy-pid-container {
+        cursor: pointer;
+      }
 
-      .tooltipped:hover::before,
-      .tooltipped:hover::after,
-      .tooltipped:active::before,
-      .tooltipped:active::after,
-      .tooltipped:focus::before,
-      .tooltipped:focus::after {
+      .copy-pid-container:hover .tooltipped::before,
+      .copy-pid-container:hover .tooltipped::after,
+      .copy-pid-container:active .tooltipped::before,
+      .copy-pid-container:active .tooltipped::after,
+      .copy-pid-container:focus .tooltipped::before,
+      .copy-pid-container:focus .tooltipped::after {
         display: inline-block;
         text-decoration: none;
       }
@@ -336,8 +339,8 @@ fs-person:not([inline]) {
             <span data-test-person-lifespan>[[lifespan]]</span>
             <div hidden$='[[!_showPid(pid, hidePid)]]'>
               &nbsp;<span class="fs-person-details__separator" hidden='[[_hideSeparator(hideSeparator, pid, lifespan)]]'>•</span>&nbsp;
-              <span class='fs-person-details__pid'>
-                <fs-icon class='copy-icon tooltipped' icon='copy' aria-label$='[[i18n("COPY_TO_CLIPBOARD")]]' on-click='_copyPid' title='' data-test-person-copy-pid-button></fs-icon>
+              <span class="copy-pid-container" on-click='_copyPid' class='fs-person-details__pid'>
+                <fs-icon id="CopyPIDIcon" aria-label$='[[i18n("COPY_TO_CLIPBOARD")]]' title='' class='copy-icon tooltipped' icon='copy' data-test-person-copy-pid-button></fs-icon>
                 <span data-test-person-pid>[[pid]]</span>
               </span>
               <input id='_pidInput' type="text" value$='[[pid]]'>
@@ -513,9 +516,9 @@ fs-person:not([inline]) {
         e.stopImmediatePropagation();
         this.$._pidInput.select();
         document.execCommand('copy');
-        target.setAttribute("aria-label", this.i18n("COPY_TO_CLIPBOARD_COMPLETE"));
+        this.$.CopyPIDIcon.setAttribute("aria-label", this.i18n("COPY_TO_CLIPBOARD_COMPLETE"));
         setTimeout(function(){
-          target.setAttribute("aria-label", that.i18n("COPY_TO_CLIPBOARD"));
+          that.$.CopyPIDIcon.setAttribute("aria-label", that.i18n("COPY_TO_CLIPBOARD"));
         }, 3000);
         window.getSelection().removeAllRanges();
       },

--- a/test/fs-person_test.html
+++ b/test/fs-person_test.html
@@ -193,6 +193,13 @@
             expect(execCommandSpy.callCount, "_copyPid did not call execCommand only once").to.equal(1);
             expect(execCommandSpy.calledWith("copy"), "_copyPid did not call execCommand with the correct parameters").to.be.true;
           });
+
+          it('should set the aria-label', function () {
+            expect(fsPersonDefault.$.CopyPIDIcon.hasAttribute("aria-label")).to.be.false;
+            fsPersonDefault._copyPid(mockEvent);
+
+            expect(fsPersonDefault.$.CopyPIDIcon.hasAttribute("aria-label")).to.be.true;
+          });
         });
 
         describe('_showPid', function() {


### PR DESCRIPTION
The functionality to copy the PID is fixed as part of this. For some reason the width of the hidden input was causing the problem for person-card. I've tested it out and increasing the width of the hidden input seems to fix the issue.

There's also a change to make it so the PID itself will copy when clicked, so the tooltip has to show when hovering over that as well. This was a ruling made by Jeff Hawkins.
I've also added a unit test for making sure the aria-label gets added on copy and I added a little variety to the demo page since all of the person renderers had the same PID.