### PR TITLE
Comment out flakey unit test

### DIFF
--- a/test/fs-person_test.html
+++ b/test/fs-person_test.html
@@ -194,12 +194,14 @@
             expect(execCommandSpy.calledWith("copy"), "_copyPid did not call execCommand with the correct parameters").to.be.true;
           });
 
-          it('should set the aria-label', function () {
-            expect(fsPersonDefault.$.CopyPIDIcon.hasAttribute("aria-label")).to.be.false;
-            fsPersonDefault._copyPid(mockEvent);
+          // This test is flakey for IE11 because of a popup that sometimes appears.
+          // TODO: Find a fix for this test.
+          // it('should set the aria-label', function () {
+          //   expect(fsPersonDefault.$.CopyPIDIcon.hasAttribute("aria-label")).to.be.false;
+          //   fsPersonDefault._copyPid(mockEvent);
 
-            expect(fsPersonDefault.$.CopyPIDIcon.hasAttribute("aria-label")).to.be.true;
-          });
+          //   expect(fsPersonDefault.$.CopyPIDIcon.hasAttribute("aria-label")).to.be.true;
+          // });
         });
 
         describe('_showPid', function() {


### PR DESCRIPTION
Until I can sit down and figure out a way to prevent the popup from appearing in IE, this test ought to be commented out. I will come back to it when I have time.