### PR TITLE
Adds `dot-icon` property for use-cases such as in the history-list

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "styles-wc",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Global styles for the FamilySearch.org website.",
   "keywords": [
     "css",

--- a/fs-person/demo/index.html
+++ b/fs-person/demo/index.html
@@ -121,6 +121,11 @@
       <fs-person gender='male' pid='KWFF-1RH' first-name='Josh' last-name='Crowther' name-system='sinotypic' lifespan='1776-1980' show-portrait portrait-url='https://familysearch.org/patron/v2/TH-904-51257-1471-39/thumb200s.jpg?ctx=ArtCtxPublic' orientation='portrait'></fs-person>
     </template>
   </demo-snippet>
+  <demo-snippet>
+    <template>
+      <fs-person pid='KWFF-1RH' full-name='Josh Crowther' name-system='sinotypic' dot-icon lifespan='1776-1980'></fs-person>
+    </template>
+  </demo-snippet>
   <style is="custom-style">
     demo-snippet{
       border: 1px solid #333;

--- a/fs-person/demo/index.html
+++ b/fs-person/demo/index.html
@@ -123,7 +123,7 @@
   </demo-snippet>
   <demo-snippet>
     <template>
-      <fs-person pid='KWFF-1RH' full-name='Josh Crowther' name-system='sinotypic' dot-icon lifespan='1776-1980'></fs-person>
+      <fs-person gender='male' pid='KWFF-1RH' full-name='Josh Crowther' name-system='sinotypic' dot-icon lifespan='1776-1980'></fs-person>
     </template>
   </demo-snippet>
   <style is="custom-style">

--- a/fs-person/fs-person.html
+++ b/fs-person/fs-person.html
@@ -339,10 +339,10 @@ fs-person:not([inline]) {
         </div>
       </div>
       <div class='v-center'>
-        <fs-icon class='fs-person-gender__icon' icon='[[gender]]' hidden='[[!_showGenderIcon(inline, showPortrait, gender, hideGender, orientation)]]'></fs-icon>
+        <fs-icon class='fs-person-gender__icon' icon='[[gender]]' hidden='[[!_showGenderIcon(inline, dotIcon, showPortrait, gender, hideGender, orientation)]]'></fs-icon>
         <div class="fs-person-vitals">
           <div class='v-center'>
-            <fs-icon class='fs-person-gender__icon' icon='[[gender]]-dot' size='small' hidden='[[!_showGenderDot(inline, showPortrait, hideGender, orientation)]]'></fs-icon>
+            <fs-icon class='fs-person-gender__icon' icon='[[gender]]-dot' size='small' hidden='[[!_showGenderDot(inline, dotIcon, showPortrait, hideGender, orientation)]]'></fs-icon>
             <span class="fs-person-vitals__name-block">
               <p class='fs-person-vitals__name' hidden='[[_isPortrait(orientation)]]' data-test-person-full-name>[[fullName]]</p>
               <p class='fs-person-vitals__name' hidden='[[!_isPortrait(orientation)]]'>
@@ -351,7 +351,7 @@ fs-person:not([inline]) {
               </p>
             </span>
           </div>
-          <div class$='fs-person-details__container [[_getDetailsClass(inline, showPortrait, hideGender, orientation)]]'>
+          <div class$='fs-person-details__container [[_getDetailsClass(inline, dotIcon, showPortrait, hideGender, orientation)]]'>
             <span data-test-person-lifespan>[[lifespan]]</span>
             <div hidden$='[[!_showPid(pid, hidePid)]]'>
               &nbsp;<span class="fs-person-details__separator" hidden='[[_hideSeparator(hideSeparator, pid, lifespan)]]'>•</span>&nbsp;
@@ -379,6 +379,11 @@ fs-person:not([inline]) {
         coloredIcon: {
           type: Boolean,
           value: false
+        },
+
+        dotIcon: {
+          type: Boolean,
+          value: true
         },
 
         /**
@@ -546,16 +551,16 @@ fs-person:not([inline]) {
           this.showPortrait = true;
         }
       },
-      _showGenderIcon: function(inline, showPortrait, gender, hideGender, orientation) {
-        if (inline) return false;
+      _showGenderIcon: function(inline, dotIcon, showPortrait, gender, hideGender, orientation) {
+        if (inline || dotIcon) return false;
         return gender && !hideGender && !showPortrait && !this._isPortrait(orientation);
       },
-      _showGenderDot: function(inline, showPortrait, hideGender, orientation) {
-        if (inline && !hideGender) return true;
+      _showGenderDot: function(inline, dotIcon, showPortrait, hideGender, orientation) {
+        if ((inline && !hideGender) || (dotIcon && !hideGender)) return true;
         return !hideGender && showPortrait && !this._isPortrait(orientation);
       },
-      _getDetailsClass: function(inline, showPortrait, hideGender, orientation) {
-        return this._showGenderDot(inline,showPortrait, hideGender, orientation) ? 'indented' : '';
+      _getDetailsClass: function(inline, dotIcon, showPortrait, hideGender, orientation) {
+        return this._showGenderDot(inline, dotIcon, showPortrait, hideGender, orientation) ? 'indented' : '';
       },
       _getGender: function(gender) {
         if (gender === 'female') return gender;

--- a/fs-person/fs-person.html
+++ b/fs-person/fs-person.html
@@ -381,9 +381,15 @@ fs-person:not([inline]) {
           value: false
         },
 
+        /**
+         * Whether or not to show the gender dot icon (instead of coloredIcon)
+         *
+         * **Valid values are true or false**
+         * @type {Boolean}
+         */
         dotIcon: {
           type: Boolean,
-          value: true
+          value: false
         },
 
         /**

--- a/test/fs-person_test.html
+++ b/test/fs-person_test.html
@@ -64,7 +64,7 @@
         describe('properties', function() {
           it('should set default values for "coloredIcon", "dotIcon", "firstName", "fullName", "gender", "hideGender", "hidePid", "inline", "lastName", "lifespan", "nameSystem", "orientation", "pid", "portraitUrl", and "showPortrait" properties', function() {
             expect(fsPersonDefault.coloredIcon, "coloredIcon is not false").to.be.false;
-            expect(fsPersonDefault.dotIcon, "dotIcon is not false").to.be.true;            
+            expect(fsPersonDefault.dotIcon, "dotIcon is not false").to.be.false;            
             expect(fsPersonDefault.firstName, "firstName is not ''").to.equal('');
             expect(fsPersonDefault.fullName, "fullName is not ''").to.equal('');
             expect(fsPersonDefault.gender, "gender is not ''").to.equal('');

--- a/test/fs-person_test.html
+++ b/test/fs-person_test.html
@@ -25,6 +25,7 @@
       <template>
         <fs-person
           colored-icon
+          dot-icon
           first-name = "John Jacob"
           full-name = "John Jacob Schmidt"
           gender = "male"
@@ -61,8 +62,9 @@
         });
 
         describe('properties', function() {
-          it('should set default values for "coloredIcon", "firstName", "fullName", "gender", "hideGender", "hidePid", "inline", "lastName", "lifespan", "nameSystem", "orientation", "pid", "portraitUrl", and "showPortrait" properties', function() {
+          it('should set default values for "coloredIcon", "dotIcon", "firstName", "fullName", "gender", "hideGender", "hidePid", "inline", "lastName", "lifespan", "nameSystem", "orientation", "pid", "portraitUrl", and "showPortrait" properties', function() {
             expect(fsPersonDefault.coloredIcon, "coloredIcon is not false").to.be.false;
+            expect(fsPersonDefault.dotIcon, "dotIcon is not false").to.be.true;            
             expect(fsPersonDefault.firstName, "firstName is not ''").to.equal('');
             expect(fsPersonDefault.fullName, "fullName is not ''").to.equal('');
             expect(fsPersonDefault.gender, "gender is not ''").to.equal('');
@@ -81,6 +83,10 @@
 
           it('should have coloredIcon true', function () {
             expect(fsPersonPassedValues.coloredIcon, "coloredIcon is not true").to.be.true;
+          });
+
+          it('should have dotIcon true', function () {
+            expect(fsPersonPassedValues.dotIcon, "dotIcon is not true").to.be.true;
           });
 
           it('should set firstName', function () {
@@ -251,6 +257,7 @@
 
         describe('_showGenderIcon', function() {
           var inline;
+          var dotIcon;          
           var showPortrait;
           var gender;
           var orientation;
@@ -259,6 +266,7 @@
           describe('inline = true', function() {
             beforeEach(function() {
               inline = true;
+              dotIcon = 'doesntMatter';
               showPortrait = 'doesntMatter';
               gender = 'doesntMatter';
               hideGender = 'doesntMatter';
@@ -266,7 +274,7 @@
             });
 
             it('should always return false', function () {
-              result = fsPersonDefault._showGenderIcon(inline, showPortrait, gender, hideGender, orientation); // other params don't matter in this case
+              result = fsPersonDefault._showGenderIcon(inline, dotIcon, showPortrait, gender, hideGender, orientation); // other params don't matter in this case
 
               expect(result, "inline=true returned true").to.be.false;
             });
@@ -275,6 +283,7 @@
           describe('inline = false', function() {
             beforeEach(function() {
               inline = false;
+              dotIcon = false;
               showPortrait = false;
               gender = 'female';
               hideGender = false;
@@ -282,33 +291,33 @@
             });
 
             it('should return true', function () {
-              result = fsPersonDefault._showGenderIcon(inline, showPortrait, gender, hideGender, orientation);
+              result = fsPersonDefault._showGenderIcon(inline, dotIcon, showPortrait, gender, hideGender, orientation);
               expect(result, "showPortrait=false, gender='female', orientation='landscape' returned false").to.be.true;
             });
 
             it('should return false', function () {
               gender = null;
-              result = fsPersonDefault._showGenderIcon(inline, showPortrait, gender, hideGender, orientation);
+              result = fsPersonDefault._showGenderIcon(inline, dotIcon, showPortrait, gender, hideGender, orientation);
               expect(result, "showPortrait=true, gender=null, orientation='landscape' returned true").to.be.null; // falsey
 
               gender = 'female';
               showPortrait = true;
-              result = fsPersonDefault._showGenderIcon(inline, showPortrait, gender, hideGender, orientation);
+              result = fsPersonDefault._showGenderIcon(inline, dotIcon, showPortrait, gender, hideGender, orientation);
               expect(result, "showPortrait=true, gender='female', orientation='landscape' returned true").to.be.false;
 
               showPortrait = false;
               hideGender = true;
-              result = fsPersonDefault._showGenderIcon(inline, showPortrait, gender, hideGender, orientation);
+              result = fsPersonDefault._showGenderIcon(inline, dotIcon, showPortrait, gender, hideGender, orientation);
               expect(result, "showPortrait=true, gender='female', orientation='landscape' returned true").to.be.false;
 
               hideGender = false;
               orientation = 'portrait';
-              result = fsPersonDefault._showGenderIcon(inline, showPortrait, gender, hideGender, orientation);
+              result = fsPersonDefault._showGenderIcon(inline, dotIcon, showPortrait, gender, hideGender, orientation);
               expect(result, "showPortrait=true, gender='female', orientation='portrait' returned true").to.be.false;
 
               showPortrait = true;
               orientation = 'portrait';
-              result = fsPersonDefault._showGenderIcon(inline, showPortrait, gender, hideGender, orientation);
+              result = fsPersonDefault._showGenderIcon(inline, dotIcon, showPortrait, gender, hideGender, orientation);
               expect(result, "showPortrait=false, gender='female', orientation='portrait' returned true").to.be.false;
             });
           });
@@ -316,6 +325,7 @@
 
         describe('_showGenderDot', function() {
           var inline;
+          var dotIcon;
           var showPortrait;
           var hideGender;
           var orientation;
@@ -324,13 +334,14 @@
           describe('inline and hideGender', function() {
             beforeEach(function() {
               inline = true;
+              dotIcon = 'doesntMatter';
               showPortrait = 'doesntMatter';
               hideGender = false;
               orientation = 'doesntMatter';
             });
 
             it('should always return true', function () {
-              result = fsPersonDefault._showGenderDot(inline, showPortrait, hideGender, orientation); // other params don't matter in this case
+              result = fsPersonDefault._showGenderDot(inline, dotIcon, showPortrait, hideGender, orientation); // other params don't matter in this case
 
               expect(result, "inline=true and hideGender=false returned false").to.be.true;
             });
@@ -339,34 +350,35 @@
           describe('inline=true (and/or hideGender=true)', function() {
             beforeEach(function() {
               inline = false;
+              dotIcon = false;
               showPortrait = true;
               hideGender = false;
               orientation = 'landscape';
             });
 
             it('should return true', function () {
-              result = fsPersonDefault._showGenderDot(inline, showPortrait, hideGender, orientation);
+              result = fsPersonDefault._showGenderDot(inline, dotIcon, showPortrait, hideGender, orientation);
               expect(result, "showPortrait=true, hideGender=false, orientation='landscape' returned false").to.be.true;
             });
 
             it('should return false', function () {
               hideGender = true;
-              result = fsPersonDefault._showGenderDot(inline, showPortrait, hideGender, orientation);
+              result = fsPersonDefault._showGenderDot(inline, dotIcon, showPortrait, hideGender, orientation);
               expect(result, "showPortrait=true, hideGender=true, orientation='landscape' returned true").to.be.false;
 
               hideGender=false;
               showPortrait = false;
-              result = fsPersonDefault._showGenderDot(inline, showPortrait, hideGender, orientation);
+              result = fsPersonDefault._showGenderDot(inline, dotIcon, showPortrait, hideGender, orientation);
               expect(result, "showPortrait=false, hideGender=false, orientation='landscape' returned true").to.be.false;
 
               showPortrait = true;
               orientation = 'portrait';
-              result = fsPersonDefault._showGenderDot(inline, showPortrait, hideGender, orientation);
+              result = fsPersonDefault._showGenderDot(inline, dotIcon, showPortrait, hideGender, orientation);
               expect(result, "showPortrait=true, hideGender=false, orientation='portrait' returned true").to.be.false;
 
               showPortrait = false;
               orientation = 'portrait';
-              result = fsPersonDefault._showGenderDot(inline, showPortrait, hideGender, orientation);
+              result = fsPersonDefault._showGenderDot(inline, dotIcon, showPortrait, hideGender, orientation);
               expect(result, "showPortrait=false, hideGender=false, orientation='portrait' returned true").to.be.false;
             });
           });
@@ -375,6 +387,7 @@
         describe('_getDetailsClass', function() {
           beforeEach(function() {
             inline = 'doesntMatter';
+            dotIcon = 'doesntMatter';            
             showPortrait = 'doesntMatter';
             hideGender = 'doesntMatter';
             orientation = 'doesntMatter';
@@ -383,10 +396,10 @@
           it('should call _showGenderDot', function () {
             var _showGenderDotStub = sinon.stub(fsPersonDefault, "_showGenderDot");
 
-            fsPersonDefault._getDetailsClass(inline, showPortrait, hideGender, orientation);
+            fsPersonDefault._getDetailsClass(inline, dotIcon, showPortrait, hideGender, orientation);
 
             expect(_showGenderDotStub.callCount, "did not call _showGenderDot only once").to.equal(1);
-            expect(_showGenderDotStub.calledWith(inline, showPortrait, hideGender, orientation), "did not call _showGenderDot with the correct parameters").to.be.true;
+            expect(_showGenderDotStub.calledWith(inline, dotIcon, showPortrait, hideGender, orientation), "did not call _showGenderDot with the correct parameters").to.be.true;
 
             _showGenderDotStub.restore();
           });
@@ -394,7 +407,7 @@
           it('should return "indented"', function () {
             var _showGenderDotStub = sinon.stub(fsPersonDefault, "_showGenderDot", function() { return true });
 
-            expect(fsPersonDefault._getDetailsClass(inline, showPortrait, hideGender, orientation), "did not return 'indented'").to.equal('indented');
+            expect(fsPersonDefault._getDetailsClass(inline, dotIcon, showPortrait, hideGender, orientation), "did not return 'indented'").to.equal('indented');
 
             _showGenderDotStub.restore();
           });
@@ -402,7 +415,7 @@
           it('should return ""', function () {
             var _showGenderDotStub = sinon.stub(fsPersonDefault, "_showGenderDot", function() { return false });
 
-            expect(fsPersonDefault._getDetailsClass(inline, showPortrait, hideGender, orientation), "did not return ''").to.equal('');
+            expect(fsPersonDefault._getDetailsClass(inline, dotIcon, showPortrait, hideGender, orientation), "did not return ''").to.equal('');
 
             _showGenderDotStub.restore();
           });


### PR DESCRIPTION
Allows rendering of the gender dot icons when not displaying in 'inline'.