### PR TITLE
Bug fixes for `&nbsp;` not disappearing and copy tooltip getting cut off.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "styles-wc",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "Global styles for the FamilySearch.org website.",
   "keywords": [
     "css",

--- a/fs-person/fs-person.html
+++ b/fs-person/fs-person.html
@@ -58,6 +58,12 @@ fs-person:not([inline]) {
       :host {
         display: inline-block;
         max-width: 100%;
+        /* z-index and position needed for hover tooltip to show above other elements.
+         * This is because of the stacking context and how z-index applies to it.
+         * Read more about the stacking context here:
+         * https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context */
+        z-index: 1;
+        position: relative;
       }
       :host([inline]) .fs-person-vitals {
         display: flex;

--- a/fs-person/fs-person.html
+++ b/fs-person/fs-person.html
@@ -354,7 +354,7 @@ fs-person:not([inline]) {
           <div class$='fs-person-details__container [[_getDetailsClass(inline, dotIcon, showPortrait, hideGender, orientation)]]'>
             <span data-test-person-lifespan>[[lifespan]]</span>
             <div hidden$='[[!_showPid(pid, hidePid)]]'>
-              &nbsp;<span class="fs-person-details__separator" hidden='[[_hideSeparator(hideSeparator, pid, lifespan)]]'>•</span>&nbsp;
+              <span class="fs-person-details__separator" hidden='[[_hideSeparator(hideSeparator, pid, lifespan)]]'>&nbsp;•&nbsp;</span>
               <span class="copy-pid-container" on-click='_copyPid' class='fs-person-details__pid'>
                 <fs-icon id="CopyPIDIcon" aria-label$='[[i18n("COPY_TO_CLIPBOARD")]]' title='' class='copy-icon tooltipped' icon='copy' data-test-person-copy-pid-button></fs-icon>
                 <span data-test-person-pid>[[pid]]</span>


### PR DESCRIPTION
Title says it all, really. I'm very confident in the `&nbsp;` fix, but the tooltip is tricky because of how `z-index` is affected by the stacking context. Increasing the `z-index` to 1000000+ won't fix it. Hopefully by giving the parent a higher `z-index` it will at least render above elements without one. This doesn't work in cases when a grand-parent element has `overflow:hidden;`, but this should at least reduce the number of times this becomes a problem.

Read more about the stacking context here: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context