### PR TITLE
Code Climate: Add bad merge check

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -30,6 +30,17 @@ engines:
       - Hack
       - HERE BE DRAGONS
       - Here Be Dragons
+  grep:
+    enabled: true
+    config:
+      patterns:
+        bad-merge:
+          pattern: <<<<<<<|=======|>>>>>>>
+          annotation: "Bad merge"
+          severity: critical
+          categories: ["Bug Risk", "Performance"]
+          content: >
+            Bad merge detected by one or more of the following strings of the form: "<<<<<<< Updated upstream", "=======", ">>>>>>> Stashed changes". In all likelihood, this will result in syntax errors when attempting to run your application.
   markdownlint:
     enabled: true
   shellcheck:

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -80,7 +80,7 @@
     "no-new-wrappers": 2, // disallows creating new instances of String, Number, and Boolean
     "no-octal": 1, // disallow use of octal literals
     "no-octal-escape": 1, // disallow use of octal escape sequences in string literals, such as var foo = "Copyright \251";
-    "no-param-reassign": 2, // disallow reassignment of function parameters (off by default)
+    "no-param-reassign": 1, // disallow reassignment of function parameters (off by default)
     "no-process-env": 2, // disallow use of process.env (off by default)
     "no-proto": 2, // disallow usage of __proto__ property
     "no-redeclare": 2, // disallow declaring the same variable more then once


### PR DESCRIPTION
Incorporate Code Climate grep engine to check for <<<<<<<|=======|>>>>>>> in code
Rename .eslintrc to .eslintrc.json.
Disable no-param-reassign rule for Tyler Graf. :)