### PR TITLE
Renamed title for demo page to correct element

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "styles-wc",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Global styles for the FamilySearch.org website.",
   "keywords": [
     "css",

--- a/fs-input-validation-eol/demo/index.html
+++ b/fs-input-validation-eol/demo/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
 
-  <title>&lt;fs-button&gt;</title>
+  <title>&lt;fs-input-validation-eol&gt;</title>
   <meta name="description" content="">
 
   <!-- Mobile -->
@@ -107,7 +107,7 @@
         input2.addEventListener(&#39;input&#39;, function() {
           validation2.status = input2.checkValidity() ? &#39;valid&#39; : &#39;invalid&#39;;
         });
-      &lt;/script&gt;  
+      &lt;/script&gt;
     </code>
   </pre>
 </body>


### PR DESCRIPTION
Changed title for fs-input-validation-eol dempo page from fs-button to fs-input-validation-eol

## To-Dos
- [x] Tests
- [x] Update demo
- [x] Increment bower.json version
