### PR TITLE
Fix tw318

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "styles-wc",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Global styles for the FamilySearch.org website.",
   "keywords": [
     "css",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "styles-wc",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Global styles for the FamilySearch.org website.",
   "keywords": [
     "css",

--- a/fs-button-eol/fs-button-eol.html
+++ b/fs-button-eol/fs-button-eol.html
@@ -314,6 +314,8 @@ Example:
           reflectToAttribute: true
         },
         /**
+         * Reflect the type attribute to the inner button. (e.g. type="button")
+         * @type {String}
          */
         type: {
           type: String,

--- a/fs-button-eol/fs-button-eol.html
+++ b/fs-button-eol/fs-button-eol.html
@@ -258,7 +258,7 @@ Example:
         padding: 0;
       }
     </style>
-    <button disabled="[[disabled]]" option$="[[option]]" size$="[[size]]" loading$="[[loading]]">
+    <button type$="[[type]]" disabled="[[disabled]]" option$="[[option]]" size$="[[size]]" loading$="[[loading]]">
       <slot></slot>
       <dom-if>
         <template is="dom-if" if="[[loading]]">
@@ -312,7 +312,14 @@ Example:
         size: {
           type: String,
           reflectToAttribute: true
+        },
+        /**
+         */
+        type: {
+          type: String,
+          reflectToAttribute: true
         }
+
       },
       /**
        * Computes the spinner that needs to be used for the button

--- a/fs-tooltip-eol/demo/index.html
+++ b/fs-tooltip-eol/demo/index.html
@@ -27,22 +27,22 @@
 <body>
   <h1>&lt;fs-tooltip-eol&gt;</h1>
   <fs-tooltip-eol>
-    <button is='fs-button-eol'>Default (above)</button>
+    <fs-button-eol>Default (above)</fs-button-eol>
     <p slot="tooltip-body">Default tooltip position is above.</p>
   </fs-tooltip-eol>
 
   <fs-tooltip-eol direction='right'>
-    <button is='fs-button-eol'>Right</button>
+    <fs-button-eol>Right</fs-button-eol>
     <p slot="tooltip-body">You can also position the tooltip to the right.</p>
   </fs-tooltip-eol>
 
   <fs-tooltip-eol direction='below'>
-    <button is='fs-button-eol'>Below</button>
+    <fs-button-eol>Below</fs-button-eol>
     <p slot="tooltip-body">Or even below the element.</p>
   </fs-tooltip-eol>
 
   <fs-tooltip-eol direction='left'>
-    <button is='fs-button-eol'>Left</button>
+    <fs-button-eol>Left</fs-button-eol>
     <p slot="tooltip-body">And lets not forget to the left.</p>
   </fs-tooltip-eol>
 </body>


### PR DESCRIPTION
Fix TW-318 fs-button-eol breaking the add flow.  When switching to using element the default type="submit" for button is used instead of the type="button" previously used for the button element. 

## Changes
reflect type attribute to the button
Bump version to 4.0.3

## To-Dos
- [ ] Tests
- [x] Update demo
- [x] Update documentation & README
- [x] Increment bower.json version
