### PR TITLE
Fixed JIRA TW 299

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "styles-wc",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "Global styles for the FamilySearch.org website.",
   "keywords": [
     "css",

--- a/fs-person-eol/fs-person-eol.html
+++ b/fs-person-eol/fs-person-eol.html
@@ -356,7 +356,7 @@ fs-person-eol:not([inline]) {
             </span>
           </div>
           <div class$='fs-person-details__container [[_getDetailsClass(inline, dotIcon, showPortrait, hideGender, orientation)]]'
-               hidden$='[[_showDetials(pid)]]'>
+               hidden$='[[_hideDetials(pid)]]'>
             <span data-test-person-lifespan>[[lifespan]]</span>
             <div hidden$='[[!_showPid(pid, hidePid)]]'>
               <span class="fs-person-details__separator" hidden='[[_hideSeparator(hideSeparator, pid, lifespan)]]'>&#9679;</span>
@@ -656,12 +656,12 @@ fs-person-eol:not([inline]) {
       _getLastName: function(first, last, nameSystem) {
         return nameSystem === 'sinotypic' ? first : last;
       },
-      _showDetials: function (pid) {
-         return ['', 'UNKNOWN'].includes(pid);
+      _hideDetials: function (pid) {
+         return pid === '' || pid === 'UNKNOWN';
       },
       _checkValidName: function (fullName, pid, i18n) {
          if (!i18n && typeof i18n("UNKNOWN_NAME") !== "string") return;
-         return (['', 'UNKNOWN'].includes(pid)) ? i18n("UNKNOWN_NAME") : fullName;
+         return (pid === '' || pid === 'UNKNOWN') ? i18n("UNKNOWN_NAME") : fullName;
       }
     });
   </script>

--- a/fs-person-eol/fs-person-eol.html
+++ b/fs-person-eol/fs-person-eol.html
@@ -659,7 +659,7 @@ fs-person-eol:not([inline]) {
       _showDetials: function (pid) {
          return ['', 'UNKNOWN'].includes(pid);
       },
-      _checkValidName(fullName, pid, i18n) {
+      _checkValidName: function (fullName, pid, i18n) {
          if (!i18n && typeof i18n("UNKNOWN_NAME") !== "string") return;
          return (['', 'UNKNOWN'].includes(pid)) ? i18n("UNKNOWN_NAME") : fullName;
       }

--- a/fs-person-eol/fs-person-eol.html
+++ b/fs-person-eol/fs-person-eol.html
@@ -347,7 +347,7 @@ fs-person-eol:not([inline]) {
           <div class='v-center'>
             <fs-icon-eol class='fs-person-gender__icon' icon='[[gender]]-dot' size='small' hidden='[[!_showGenderDot(inline, dotIcon, showPortrait, hideGender, orientation)]]'></fs-icon-eol>
             <span class="fs-person-vitals__name-block">
-              <p class='fs-person-vitals__name' hidden='[[_isPortrait(orientation)]]' data-test-person-full-name><span class="person-label" hidden$="[[!label]]">[[label]]: </span>[[_checkValidName(fullName, i18n)]]</p>
+              <p class='fs-person-vitals__name' hidden='[[_isPortrait(orientation)]]' data-test-person-full-name><span class="person-label" hidden$="[[!label]]">[[label]]: </span>[[_checkValidName(fullName, pid, i18n)]]</p>
               <p class='fs-person-vitals__name' hidden='[[!_isPortrait(orientation)]]'>
                 <span class="person-label" hidden$="[[!label]]">[[label]]: </span>
                 <span data-test-person-given-name>[[_getFirstName(firstName, lastName, nameSystem)]]</span>
@@ -659,9 +659,9 @@ fs-person-eol:not([inline]) {
       _showDetials: function (pid) {
          return ['', 'UNKNOWN'].includes(pid);
       },
-      _checkValidName(fullName, i18n) {
+      _checkValidName(fullName, pid, i18n) {
          if (!i18n && typeof i18n("UNKNOWN_NAME") !== "string") return;
-         return (fullName !== "UNKNOWN") ? fullName : i18n("UNKNOWN_NAME");
+         return (['', 'UNKNOWN'].includes(pid)) ? i18n("UNKNOWN_NAME") : fullName;
       }
     });
   </script>

--- a/fs-person-eol/fs-person-eol.html
+++ b/fs-person-eol/fs-person-eol.html
@@ -347,7 +347,7 @@ fs-person-eol:not([inline]) {
           <div class='v-center'>
             <fs-icon-eol class='fs-person-gender__icon' icon='[[gender]]-dot' size='small' hidden='[[!_showGenderDot(inline, dotIcon, showPortrait, hideGender, orientation)]]'></fs-icon-eol>
             <span class="fs-person-vitals__name-block">
-              <p class='fs-person-vitals__name' hidden='[[_isPortrait(orientation)]]' data-test-person-full-name><span class="person-label" hidden$="[[!label]]">[[label]]: </span>[[fullName]]</p>
+              <p class='fs-person-vitals__name' hidden='[[_isPortrait(orientation)]]' data-test-person-full-name><span class="person-label" hidden$="[[!label]]">[[label]]: </span>[[_checkValidName(fullName, i18n)]]</p>
               <p class='fs-person-vitals__name' hidden='[[!_isPortrait(orientation)]]'>
                 <span class="person-label" hidden$="[[!label]]">[[label]]: </span>
                 <span data-test-person-given-name>[[_getFirstName(firstName, lastName, nameSystem)]]</span>
@@ -355,7 +355,8 @@ fs-person-eol:not([inline]) {
               </p>
             </span>
           </div>
-          <div class$='fs-person-details__container [[_getDetailsClass(inline, dotIcon, showPortrait, hideGender, orientation)]]'>
+          <div class$='fs-person-details__container [[_getDetailsClass(inline, dotIcon, showPortrait, hideGender, orientation)]]'
+               hidden$='[[_showDetials(pid)]]'>
             <span data-test-person-lifespan>[[lifespan]]</span>
             <div hidden$='[[!_showPid(pid, hidePid)]]'>
               <span class="fs-person-details__separator" hidden='[[_hideSeparator(hideSeparator, pid, lifespan)]]'>&#9679;</span>
@@ -654,6 +655,13 @@ fs-person-eol:not([inline]) {
       },
       _getLastName: function(first, last, nameSystem) {
         return nameSystem === 'sinotypic' ? first : last;
+      },
+      _showDetials: function (pid) {
+         return ['', 'UNKNOWN'].includes(pid);
+      },
+      _checkValidName(fullName, i18n) {
+         if (!i18n && typeof i18n("UNKNOWN_NAME") !== "string") return;
+         return (fullName !== "UNKNOWN") ? fullName : i18n("UNKNOWN_NAME");
       }
     });
   </script>

--- a/fs-person-eol/locales/fs-person-eol_de.json
+++ b/fs-person-eol/locales/fs-person-eol_de.json
@@ -1,4 +1,5 @@
 {
+  "UNKNOWN_NAME": "[Unbekannter Name]",
   "_LRM_PKTAG970": "styles-wc_2_146 - CHANGES-ONLY",
   "COPY_TOOLTIP": "ID in die Zwischenablage kopieren.",
   "COPY_TO_CLIPBOARD": "ID-Nummer in die Zwischenablage kopieren.",

--- a/fs-person-eol/locales/fs-person-eol_en.json
+++ b/fs-person-eol/locales/fs-person-eol_en.json
@@ -1,4 +1,5 @@
 {
+  "UNKNOWN_NAME": "[Unknown Name]",
   "COPY_TO_CLIPBOARD": "Copy ID",
   "COPY_TO_CLIPBOARD_COMPLETE": "ID copied."
 }

--- a/fs-person-eol/locales/fs-person-eol_eo.json
+++ b/fs-person-eol/locales/fs-person-eol_eo.json
@@ -1,4 +1,5 @@
 {
+  "UNKNOWN_NAME": "[[Ûñķñöŵñ Ñåɱé]------- П國カ내]",
   "COPY_TO_CLIPBOARD": "[Çöþý ÎÐ------- П國カ내]",
   "COPY_TO_CLIPBOARD_COMPLETE": "[ÎÐ çöþîéð.------------- П國カ내]"
 }

--- a/fs-person-eol/locales/fs-person-eol_es.json
+++ b/fs-person-eol/locales/fs-person-eol_es.json
@@ -1,4 +1,5 @@
 {
+  "UNKNOWN_NAME": "[Nombre desconocido]",
   "_LRM_PKTAG502": "styles-wc_2_101 - CHANGES-ONLY",
   "COPY_TOOLTIP": "Copiar el ID al portapapeles.",
   "COPY_TO_CLIPBOARD": "Copiar el ID al portapapeles.",

--- a/fs-person-eol/locales/fs-person-eol_fr.json
+++ b/fs-person-eol/locales/fs-person-eol_fr.json
@@ -1,4 +1,5 @@
 {
+  "UNKNOWN_NAME": "[Nom inconnu]",
   "_LRM_PKTAG995": "styles-wc_2_102 - CHANGES-ONLY",
   "COPY_TOOLTIP": "Copier le numéro d’identification dans le presse-papier.",
   "COPY_TO_CLIPBOARD": "Copier le numéro d’identification dans le presse-papier.",

--- a/fs-person-eol/locales/fs-person-eol_it.json
+++ b/fs-person-eol/locales/fs-person-eol_it.json
@@ -1,4 +1,5 @@
 {
+  "UNKNOWN_NAME": "[Nome sconosciuto]",
   "_LRM_PKTAG548": "styles-wc_2_103 - CHANGES-ONLY",
   "COPY_TOOLTIP": "Copia il codice identificativo sul blocco appunti.",
   "COPY_TO_CLIPBOARD": "Copia il codice identificativo sul blocco appunti.",

--- a/fs-person-eol/locales/fs-person-eol_ja.json
+++ b/fs-person-eol/locales/fs-person-eol_ja.json
@@ -1,4 +1,5 @@
 {
+  "UNKNOWN_NAME": "[不明な名前]",
   "_LRM_PKTAG166": "styles-wc_2_104 - CHANGES-ONLY",
   "COPY_TOOLTIP": "クリップボードにIDをコピーします。",
   "COPY_TO_CLIPBOARD": "クリップボードにIDをコピーします。",

--- a/fs-person-eol/locales/fs-person-eol_ko.json
+++ b/fs-person-eol/locales/fs-person-eol_ko.json
@@ -1,4 +1,5 @@
 {
+  "UNKNOWN_NAME": "[이름 미상]",
   "_LRM_PKTAG891": "styles-wc_2_105 - CHANGES-ONLY",
   "COPY_TOOLTIP": "클립보드에 ID 복사하기.",
   "COPY_TO_CLIPBOARD": "클립보드에 ID 복사하기.",

--- a/fs-person-eol/locales/fs-person-eol_pt.json
+++ b/fs-person-eol/locales/fs-person-eol_pt.json
@@ -1,4 +1,5 @@
 {
+  "UNKNOWN_NAME": "[Nome Desconhecido]",
   "_LRM_PKTAG447": "styles-wc_2_106 - CHANGES-ONLY",
   "COPY_TOOLTIP": "Copiar o número de ID para a área de transferência.",
   "COPY_TO_CLIPBOARD": "Copiar o número de ID para a área de transferência.",

--- a/fs-person-eol/locales/fs-person-eol_ru.json
+++ b/fs-person-eol/locales/fs-person-eol_ru.json
@@ -1,4 +1,5 @@
 {
+  "UNKNOWN_NAME": "[Неизвестное имя]",
   "_LRM_PKTAG467": "styles-wc_2_107 - CHANGES-ONLY",
   "COPY_TOOLTIP": "Копировать номер (ID) в буфер обмена.",
   "COPY_TO_CLIPBOARD": "Копировать номер (ID) в буфер обмена.",

--- a/fs-person-eol/locales/fs-person-eol_zh.json
+++ b/fs-person-eol/locales/fs-person-eol_zh.json
@@ -1,4 +1,5 @@
 {
+  "UNKNOWN_NAME": "(姓名不詳)",
   "_LRM_PKTAG946": "styles-wc_2_108 - CHANGES-ONLY",
   "COPY_TOOLTIP": "複製 ID 到剪貼簿",
   "COPY_TO_CLIPBOARD": "複製 ID 到剪貼簿。",


### PR DESCRIPTION
There were some styling issues with the Alternate Spouses dialog.

## Changes
- When a spouse is "UNKNOWN" hide details.
- Added locales for the text: "[UNKNOWN NAME]"

## To-Dos
- [ ] Tests
- [X] Increment bower.json version
