### PR TITLE
TK-224503. Adds colorScheme property & nightfall styles.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "styles-wc",
-  "version": "4.0.7",
+  "version": "4.1.0",
   "description": "Global styles for the FamilySearch.org website.",
   "keywords": [
     "css",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "styles-wc",
-  "version": "4.0.6",
+  "version": "4.0.7",
   "description": "Global styles for the FamilySearch.org website.",
   "keywords": [
     "css",

--- a/fs-person-eol/demo/index.html
+++ b/fs-person-eol/demo/index.html
@@ -39,7 +39,7 @@
       demo-snippet.dark {
         --demo-snippet-demo: {
           background-color: #333331;
-        }
+        };
       }
       .big-portrait {
         --fs-person-portrait: {

--- a/fs-person-eol/demo/index.html
+++ b/fs-person-eol/demo/index.html
@@ -25,36 +25,43 @@
   <link rel="import" href="../fs-person-eol.html">
 </head>
 <body>
-  <style is="custom-style">
-    demo-snippet{
-      border: 1px solid #333;
-      margin-bottom: 5px;
-    }
-    fs-person-eol {
-      --fs-person-name-v-center: {
-        overflow: visible;
+  <custom-style>
+    <style is="custom-style">
+      demo-snippet{
+        border: 1px solid #333;
+        margin-bottom: 5px;
       }
-    }
-    .big-portrait {
-      --fs-person-portrait: {
-        width: 200px;
-        height: 200px;
-      };
-    }
-    .bold-text {
-      --fs-person-name: {
-        font-weight: bold;
-      };
-    }
-    .top-align-text {
-      --fs-person-container: {
-        align-items: flex-start;
-      };
-    }
-    .wrapper {
-      max-width: 500px;
-    }
-  </style>
+      fs-person-eol {
+        --fs-person-name-v-center: {
+          overflow: visible;
+        };
+      }
+      demo-snippet.dark {
+        --demo-snippet-demo: {
+          background-color: #333331;
+        }
+      }
+      .big-portrait {
+        --fs-person-portrait: {
+          width: 200px;
+          height: 200px;
+        };
+      }
+      .bold-text {
+        --fs-person-name: {
+          font-weight: bold;
+        };
+      }
+      .top-align-text {
+        --fs-person-container: {
+          align-items: flex-start;
+        };
+      }
+      .wrapper {
+        max-width: 500px;
+      }
+    </style>
+  </custom-style>
   <div class="wrapper">
     <demo-snippet>
       <template>
@@ -109,6 +116,11 @@
     <demo-snippet>
       <template>
         <fs-person-eol gender='male' colored-icon full-name='Josh Crowther' show-portrait></fs-person-eol>
+      </template>
+    </demo-snippet>
+    <demo-snippet class='dark'>
+      <template>
+        <fs-person-eol color-scheme='nightfall' gender='female' full-name='Jenna Crowther' show-portrait pid='KWFF-1RH'></fs-person-eol>
       </template>
     </demo-snippet>
     <demo-snippet>

--- a/fs-person-eol/fs-person-eol.html
+++ b/fs-person-eol/fs-person-eol.html
@@ -166,6 +166,15 @@ fs-person-eol:not([inline]) {
         color: #333331;
       }
 
+      .fs-person__container.nightfall .fs-person-vitals__name {
+        color: #fff;
+      }
+
+      .fs-person__container.nightfall .fs-person-details__container,
+      .fs-person__container.nightfall .fs-person-details__separator {
+        color: #ecebea;
+      }
+
       :host([orientation='portrait']) .fs-person__container {
         flex-direction: column;
       }
@@ -196,6 +205,12 @@ fs-person-eol:not([inline]) {
         position: relative;
         @apply(--fs-person-portrait);
       }
+
+      .fs-person__container.nightfall .fs-person-portrait__container {
+        background-color: #57585a;
+        border-color: #8c8d8f;
+      }
+
       :host([orientation='portrait']) .fs-person-portrait__container {
         margin-right: 0;
       }
@@ -265,10 +280,10 @@ fs-person-eol:not([inline]) {
       }
 
       .fs-person-details__separator{
-        vertical-align: top;
-        padding-left: 6px;
+        margin-top: -2px;
+        margin-bottom: 2px;
         padding-right: 6px;
-        color: #333331;
+        padding-left: 6px;
       }
 
       /* The actual popup (appears on top) */
@@ -334,7 +349,7 @@ fs-person-eol:not([inline]) {
         text-overflow: ellipsis;
       }
     </style>
-    <div class$='fs-person__container locale-[[language]]' data-test-person='[[pid]]'>
+    <div class$='fs-person__container locale-[[language]] [[colorScheme]]' data-test-person='[[pid]]'>
       <div class="fs-person-portrait" hidden='[[inline]]'>
         <div class='fs-person-portrait__container' hidden='[[!showPortrait]]'>
           <dom-if>
@@ -390,6 +405,18 @@ fs-person-eol:not([inline]) {
         coloredIcon: {
           type: Boolean,
           value: false
+        },
+
+        /**
+         * Which color scheme to display: daybreak or nightfall.
+         *
+         * **Valid values are daybreak or nightfall. If not specified, default is daybreak.**
+         * @type {String}
+         */
+        colorScheme: {
+          type: String,
+          reflectToAttribute: true,
+          value: 'daybreak'
         },
 
         /**

--- a/test/fs-person_test.html
+++ b/test/fs-person_test.html
@@ -24,6 +24,7 @@
     <test-fixture id="fs-person-passed-values">
       <template>
         <fs-person-eol
+          color-scheme = 'nightfall'
           colored-icon
           dot-icon
           first-name = "John Jacob"
@@ -62,7 +63,8 @@
         });
 
         describe('properties', function() {
-          it('should set default values for "coloredIcon", "dotIcon", "firstName", "fullName", "gender", "hideGender", "hidePid", "inline", "lastName", "lifespan", "nameSystem", "orientation", "pid", "portraitUrl", and "showPortrait" properties', function() {
+          it('should set default values for "colorScheme", "coloredIcon", "dotIcon", "firstName", "fullName", "gender", "hideGender", "hidePid", "inline", "lastName", "lifespan", "nameSystem", "orientation", "pid", "portraitUrl", and "showPortrait" properties', function() {
+            expect(fsPersonDefault.colorScheme, "colorScheme is not daybreak").to.equal('daybreak');
             expect(fsPersonDefault.coloredIcon, "coloredIcon is not false").to.be.false;
             expect(fsPersonDefault.dotIcon, "dotIcon is not false").to.be.false;
             expect(fsPersonDefault.firstName, "firstName is not ''").to.equal('');
@@ -79,6 +81,10 @@
             expect(fsPersonDefault.pid, "pid is not ''").to.equal('');
             expect(fsPersonDefault.portraitUrl, "portraitUrl is not ''").to.equal('');
             expect(fsPersonDefault.showPortrait, "showPortrait is not false").to.be.false;
+          });
+
+          it('should set colorScheme to "nightfall"', function () {
+            expect(fsPersonPassedValues.colorScheme, "colorScheme is not 'nightfall'").to.equal('nightfall');
           });
 
           it('should have coloredIcon true', function () {


### PR DESCRIPTION

Adds colorScheme property & nightfall styles.

## Changes
- Bumps version
- Adds nightfall styles & colorScheme property (reflected to attribute as requested)
- Adds tests.
- Updates documentation
- Updates demo. Demo page styles were not working without the `<custom-style>` element.

## To-Dos
- [x] Tests
- [x] Update demo
- [x] Update documentation & README
- [x] Increment bower.json version
