### PR TITLE
Bug Fix: TW-419 - /pedigree/false and /pedigree/undefined calls.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "styles-wc",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "Global styles for the FamilySearch.org website.",
   "keywords": [
     "css",

--- a/fs-person-eol/fs-person-eol.html
+++ b/fs-person-eol/fs-person-eol.html
@@ -361,11 +361,9 @@ fs-person-eol:not([inline]) {
     <div class$='fs-person__container locale-[[language]] [[colorScheme]]' data-test-person='[[pid]]'>
       <div class="fs-person-portrait" hidden='[[inline]]'>
         <div class='fs-person-portrait__container' hidden='[[!showPortrait]]'>
-          <dom-if>
-            <template is='dom-if' if='[[portraitUrl]]'>
-              <img class='fs-person-portrait__portrait-image' src="[[portraitUrl]]" on-error="handlePortraitError" data-test-person-portrait>
-            </template>
-          </dom-if>
+          <template is='dom-if' if='[[portraitUrl]]'>
+            <img class='fs-person-portrait__portrait-image' src$="[[portraitUrl]]" on-error="handlePortraitError" data-test-person-portrait>
+          </template>
           <fs-icon-eol icon='[[_getGenderIcon(gender, coloredIcon)]]' class='fs-person-portrait__portrait-icon'></fs-icon-eol>
         </div>
       </div>


### PR DESCRIPTION
Even though the image is in a `dom-if`, the `src` property of the image is being set to the `portraitUrl`. The `portraitUrl` is undefined when we turn off portraits in the pedigree because the data doesn't return them. So the image still makes a request to `/pedigree/undefined` and then when that fails, there's an error handler on the image that sets `portraitUrl` to `false`, so it makes another request to `/pedigree/false`. The solution is to make the `src` an attribute only (`src$=""`) which doesn't get set if the `dom-if` is set to false.

## Changes
- `src=""`=>`src$=""`
- Remove `<dom-if>`s because of this: https://www.polymer-project.org/2.0/docs/devguide/templates#dom-if

## To-Dos
- [x] Increment bower.json version
