### PR TITLE
fs-person: Style tweak

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "styles-wc",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "description": "Global styles for the FamilySearch.org website.",
   "keywords": [
     "css",

--- a/fs-person-eol/fs-person-eol.html
+++ b/fs-person-eol/fs-person-eol.html
@@ -306,13 +306,11 @@ fs-person-eol:not([inline]) {
       }
 
       span.hover-pid{
-        border-bottom: 1px transparent solid;
         cursor: pointer;
       }
 
       span.hover-pid:hover{
-        border-bottom: 1px black solid;
-        cursor: pointer;
+        text-decoration: underline;
       }
 
       .copy-popup-text:hover{


### PR DESCRIPTION
Use underline instead of border to have correct hover underline color in daybreak/nightfall mode.

Before:
![screen shot 2017-10-16 at 1 14 39 pm](https://user-images.githubusercontent.com/2700098/31630519-0724d67a-b274-11e7-882f-d1fee1356806.png)

After:
![1](https://user-images.githubusercontent.com/2700098/31629817-0150b112-b272-11e7-9912-81ae424131e7.gif)
