### PR TITLE
Fix bad i18n check

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "styles-wc",
-  "version": "4.1.7",
+  "version": "4.1.8",
   "description": "Global styles for the FamilySearch.org website.",
   "keywords": [
     "css",

--- a/fs-person-eol/fs-person-eol.html
+++ b/fs-person-eol/fs-person-eol.html
@@ -696,7 +696,7 @@ fs-person-eol:not([inline]) {
          return pid === '' || pid === 'UNKNOWN';
       },
       _checkValidName: function (fullName, pid, i18n) {
-         if (!i18n && typeof i18n("UNKNOWN_NAME") !== "string") return;
+         if (!i18n || typeof i18n("UNKNOWN_NAME") !== "string") return;
          return (pid === '' || pid === 'UNKNOWN') ? i18n("UNKNOWN_NAME") : fullName;
       }
     });


### PR DESCRIPTION
Fix bad i18n check.  This check is preventing wci18n update to simplify boilerplate code.

## Changes
Ensure that undefined will not cause an exception.

## To-Dos
- [ ] Tests
- [x] Increment bower.json version
