### PR TITLE
fix portrait so it no longer drops a few pixels when opening children dropdown

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "styles-wc",
-  "version": "4.1.8",
+  "version": "4.1.9",
   "description": "Global styles for the FamilySearch.org website.",
   "keywords": [
     "css",

--- a/fs-person-eol/fs-person-eol.html
+++ b/fs-person-eol/fs-person-eol.html
@@ -193,7 +193,6 @@ fs-person-eol:not([inline]) {
         align-items: center;
         justify-content: center;
         overflow: hidden;
-        position: relative;
         @apply(--fs-person-portrait);
       }
 
@@ -215,10 +214,7 @@ fs-person-eol:not([inline]) {
       .fs-person-portrait__portrait-image {
         width: 100%;
         height: 100%;
-        /* Bug fix so portraits and broken images don't appear side-by-side with icon: */
-        position: absolute;
-        top: 0px; /* Required for ie11 */
-        left: 0px;
+        flex-shrink: 0;
         @apply(--fs-person-portrait-image);
       }
       a:visited {


### PR DESCRIPTION
Tested in IE11, Chrome, Safari, and FireFox. `flex-shrink: 0` fixes the portrait and the icon being side by side in IE11, and removing the relative/absolute positions fixes the portraits so they no longer drop when opening the children dropdown.