### PR TITLE
add empty alt attribute to images

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "styles-wc",
-  "version": "4.1.10",
+  "version": "4.1.11",
   "description": "Global styles for the FamilySearch.org website.",
   "keywords": [
     "css",

--- a/fs-person-eol/fs-person-eol.html
+++ b/fs-person-eol/fs-person-eol.html
@@ -356,7 +356,7 @@ fs-person-eol:not([inline]) {
       <div class="fs-person-portrait" hidden='[[inline]]'>
         <div class='fs-person-portrait__container' hidden='[[!showPortrait]]'>
           <template is='dom-if' if='[[portraitUrl]]'>
-            <img class='fs-person-portrait__portrait-image' src$="[[portraitUrl]]" on-error="handlePortraitError" data-test-person-portrait>
+            <img alt="" class='fs-person-portrait__portrait-image' src$="[[portraitUrl]]" on-error="handlePortraitError" data-test-person-portrait>
           </template>
           <fs-icon-eol icon='[[_getGenderIcon(gender, coloredIcon)]]' class='fs-person-portrait__portrait-icon'></fs-icon-eol>
         </div>


### PR DESCRIPTION
Otherwise screen readers read the entire image url