### PR TITLE
Make travis build match electric flow build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
   - npm install -g bower
 install:
   # pipe bower install output through tee to create a log to parse for errors and preserve exit code
-  - 'bower install --force-latest 2>&1 | tee bower-debug.log; ( exit ${PIPESTATUS[0]} )'
+  - 'bower install --config.interactive=false 2>&1 | tee bower-debug.log; ( exit ${PIPESTATUS[0]} )'
   - npm install
 before_script:
   - node_modules/fs-common-build-scripts/bin/before_script.sh


### PR DESCRIPTION
For all repos maintained by TreeWeb we are changing the travis build
away from using

    --forceLatest

the Electric Flow build, and normal build script, both use

    bower install --config.interactive=false

We want them all to match.

## Changes
- Make travis use --config.interactive=false instead of --forceLatest.
