### PR TITLE
Fix - TW-978: Make background color be transparent.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "styles-wc",
-  "version": "4.2.3",
+  "version": "4.2.4",
   "description": "Global styles for the FamilySearch.org website.",
   "keywords": [
     "css",

--- a/fs-person-eol/fs-person-eol.html
+++ b/fs-person-eol/fs-person-eol.html
@@ -333,8 +333,9 @@ fs-person-eol:not([inline]) {
       }
 
       button#copy-text {
-        padding: 5px;
+        background-color: transparent;
         border: none;
+        padding: 5px;
       }
 
       .fs-person-details__container .fs-person-ls-container {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "styles-wc",
-  "version": "4.2.3",
+  "version": "4.2.4",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
Fix - TW-978: Make background color be transparent. This fixes problem in Safari where the background color was dark gray.

## To-Dos
- [x] Increment version in bower.json & package.json.
