### PR TITLE
Build-related updates

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,7 +1,9 @@
+**/.*
 **/*bower_components*/**
 **/*min.*
 **/*node_modules*/**
 **/*polyfill*
+**/coverage/**
 **/demo/**
 **/reports/**
 **/test/**

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,11 +1,16 @@
 module.exports = {
   extends: [
-    'frontier',
-    'tree'
+    'eslint-config-frontier',
+    'eslint-config-tree',
   ],
   plugins: [
     // Enable plugins that are not natively supported by Code Climate. Otherwise results in build errors.
+    'eslint-plugin-bestpractices',
     'eslint-plugin-deprecate',
-    'eslint-plugin-sonarjs'
-  ],
+    'eslint-plugin-no-only-tests',
+    'eslint-plugin-no-skip-tests',
+    'eslint-plugin-promise',
+    'eslint-plugin-sonarjs',
+    'eslint-plugin-test-selectors' // NOTE: Only runs against JSX
+  ]
 }

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Bug reports are primarily handled through [JIRA](https://almtools.ldschurch.org/
 
 ### Contributing Pull Requests
 
-- Follow ESLint/CSSLint best practices. Enforced by Code Climate, `semistandard`, and `stylelint`.
+- Follow ESLint/CSSLint best practices. Enforced by Code Climate, `eslint`, and `stylelint`.
 - Increment bower.json version (used to automatically tag a new release).
 - **Include tests that test the range of behavior that changes with your PR.** If your PR fixes a bug, make sure your tests capture that bug. If your PR adds new behavior, make sure that behavior is fully tested. Every PR must include associated tests (unit, component, acceptance) as appropriate.
 - Update any associated documentation affected by your change.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,53 +1,20 @@
-addons:
-  sauce_connect: true
-# Branch whitelist
-branches:
-  only:
-    - master
-# Caching of bower_components & node_modules disabled, due to an increase in delayed breakages
-cache:
-  npm: false
-  directories: null
-dist: trusty
-language: node_js
-node_js:
-  - 10
-notifications:
-  email:
-    on_success: never
-    on_failure: change
-  slack:
-    # Custom template used because SUCCESS/FAILURE is all the way at the end by default
-    template:
-      - '%{result}: %{repository} <%{build_url}|#%{build_number}>  (<%{compare_url}|%{commit}>)'
-      - "\tin %{duration} for %{author}'s commit:"
-      - "\t\"%{commit_subject}\""
-    rooms:
-      - 'familysearch:S4NvL7BI3BFGOMfoiSCfARk5#treeweb-gold-builds'
-    on_pull_requests: false
-    on_success: always
-    on_failure: change
-    on_start: never
+version: ~> 1.0
 
-before_install:
-  # Create .netrc for private repo install
-  - 'echo -e "machine github.com\n  login $GITHUB_AUTH_TOKEN" >> ~/.netrc'
-  - npm install -g bower
-install:
-  # pipe bower install output through tee to create a log to parse for errors and preserve exit code
-  - 'bower install --config.interactive=false 2>&1 | tee bower-debug.log; ( exit ${PIPESTATUS[0]} )'
-  - npm install
-before_script:
-  - node_modules/fs-common-build-scripts/bin/before_script.sh
-script:
-  # Run linting checks, suppressing warnings for cleanliness
-  - npx eslint '**/*.html' '**/*.json' --quiet
-  - stylelint '**/*.html' '**/*.css'
-  # Run tests
-  - 'npx wct --configFile wct.conf.windows.json --skip-plugin local && npx wct --configFile wct.conf.json --skip-plugin local'
-after_success:
-  - node node_modules/fs-common-build-scripts/bin/create_release.js
-after_failure:
-  - node_modules/fs-common-build-scripts/bin/report_failure_details.sh
-after_script:
-  - node_modules/fs-common-build-scripts/bin/after_script.sh
+# This Travis CI configuration makes use of imports (https://docs.travis-ci.com/user/build-config-imports/) to commonize and simplify build configuration. Utilizes shallow merge, allowing overwrites for most root level sections, and deep merge for notifications.
+import:
+  - source: fs-webdev/fs-common-build-scripts:travis/base.yml@v2
+    mode: merge
+  - source: fs-webdev/fs-common-build-scripts:travis/sauce.yml@v2
+    mode: merge
+  - source: fs-webdev/fs-common-build-scripts:travis/notifications.yml@v2
+    mode: deep_merge
+  - source: fs-webdev/fs-common-build-scripts:travis/notifications/tw-red.yml@v2
+    mode: deep_merge
+  - source: fs-webdev/fs-common-build-scripts:travis/before.yml@v2
+    mode: merge
+  - source: fs-webdev/fs-common-build-scripts:travis/install_with_bower.yml@v2
+    mode: deep_merge_prepend
+  - source: fs-webdev/fs-common-build-scripts:travis/scripts.yml@v2
+    mode: merge
+
+# Put anything additional you wish to have happen before running tests in an `install` section.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The FamilySearch Element Catalog is located at: [https://www.familysearch.org/fr
 
 For detail about automatic releases, test plugins, pre-commit hooks, and standards enforcement, see: [fs-common-build-scripts](https://github.com/fs-webdev/fs-common-build-scripts#)
 
-> IMPORTANT NOTE: When running package dependency commands (i.e. `wct`, `standard`), you need to prefix the command with [`npx`](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b).
+> IMPORTANT NOTE: When running package dependency commands (i.e. `wct`), you need to prefix the command with [`npx`](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b).
 
 ## Running Tests
 
@@ -48,22 +48,24 @@ For detail about automatic releases, test plugins, pre-commit hooks, and standar
 
 This component is set up to be tested via [web-component-tester](https://github.com/Polymer/web-component-tester).
 
-To run tests locally, run:
+To run tests locally (skipping sauce), run:
 
 ```bash
 npm test
 ```
 
-which will run the standards checks through `semistandard` and `stylelint`, and then the unit tests via `wct`.
+which will run unit tests locally via `wct`.
+
+To run against sauce (skipping local), run:
 
 ```bash
-npx wct --skip-plugin sauce
+npm run test:ci
 ```
 
 If you need to debug locally (keeping the browser open), run:
 
 ```bash
-npx wct --skip-plugin sauce -p
+npm run test:persistent
 ```
 
 or

--- a/package.json
+++ b/package.json
@@ -18,10 +18,7 @@
   },
   "homepage": "https://github.com/fs-webdev/styles-wc#readme",
   "devDependencies": {
-    "eslint-config-frontier": "github:fs-webdev/eslint-config-frontier",
-    "eslint-config-tree": "github:fs-webdev/eslint-config-tree#semver:^1",
-    "fs-common-build-scripts": "github:fs-webdev/fs-common-build-scripts#semver:^1",
-    "husky": "^2"
+    "fs-common-build-scripts": "github:fs-webdev/fs-common-build-scripts#semver:^2"
   },
   "husky": {
     "hooks": {
@@ -40,12 +37,11 @@
     "postinstall": "bower install",
     "lint": "eslint '**/*.html' '**/*.json' && stylelint '**/*.html' '**/*.css'",
     "lint:fix": "eslint '**/*.html' '**/*.json' --fix && stylelint '**/*.html' '**/*.css' --fix",
-    "lint:staged": "node node_modules/fs-common-build-scripts/bin/pre_commit_checks.js && lint-staged",
-    "standard": "npm run lint",
-    "standard-fix": "npm run lint:fix",
+    "lint:quiet": "eslint '**/*.html' '**/*.json' --quiet && stylelint '**/*.html' '**/*.css' --quiet",
+    "lint:staged": "lint-staged && node node_modules/fs-common-build-scripts/bin/pre_commit_checks.js",
     "test": "wct --skip-plugin sauce",
-    "test-p": "wct --skip-plugin sauce -p",
-    "test-s": "wct --configFile wct.conf.windows.json --skip-plugin local && wct --configFile wct.conf.json --skip-plugin local"
+    "test:ci": "wct --configFile wct.conf.windows.json --skip-plugin local && wct --configFile wct.conf.json --skip-plugin local",
+    "test:persistent": "wct --skip-plugin sauce -p"
   },
   "stylelint": {
     "about": "https://github.com/stylelint/stylelint/blob/master/docs/user-guide/rules.md#possible-errors",

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -40,7 +40,7 @@
       "thresholds": {
         "global": {
           "statements": 85,
-          "branches": 90,
+          "branches": 95,
           "functions": 90,
           "lines": 85
         }
@@ -48,8 +48,8 @@
     },
     "size-limit": {
       "path": "styles-wc.html",
-      "limitNoPolymer": "100 KB",
-      "limitNoExternals": "40 KB"
+      "limitNoPolymer": "120 KB",
+      "limitNoExternals": "60 KB"
     }
   }
 }


### PR DESCRIPTION
Utilize fs-common-build-scripts#2 shared import files for common Travis CI configuration.
Enable additional helpful ESLint plugins.
Remove redundant devDependencies.
Remove semistandard references and commands.
Clean up .dotfile configurations.
Add uniform `lint:quiet` and `test:ci` commands (required by common configuration script: scripts.yml).